### PR TITLE
ensure-attestation-report-timestamp-is-within-24-hours

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,16 +42,25 @@ version = '2.0.0-alpha.7'
 default-features = false
 version = '2.0.0-alpha.7'
 
+[dependencies.timestamp]
+default-features = false
+package = "pallet-timestamp"
+version = "2.0.0-alpha.7"
+
 [dev-dependencies]
 hex-literal = "*"
 
-[dev-dependencies.sp-runtime]
+[dependencies.sp-runtime]
 default-features = false
 version = '2.0.0-alpha.7'
 
 [dev-dependencies.externalities]
 package = "sp-externalities"
 version = "0.8.0-alpha.7"
+
+[dev-dependencies.balances]
+package = "pallet-balances"
+version = '2.0.0-alpha.7'
 
 [features]
 default = ['std']
@@ -63,4 +72,5 @@ std = [
     'sp-std/std',    
     'sp-io/std',
     'sp-core/std',
+    'timestamp/std'
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,11 +262,11 @@ impl<T: Trait> Module<T> {
     }
 
     fn ensure_timestamp_within_24_hours(report_timestamp: u64) -> DispatchResult {
-        if <timestamp::Module<T>>::get()
+        let elapsed_time = <timestamp::Module<T>>::get()
             .checked_sub(&T::Moment::saturated_from(report_timestamp.into()))
-            .ok_or("Underflow while calculating elapsed time since report creation")?
-            < T::MomentsPerDay::get()
-        {
+            .ok_or("Underflow while calculating elapsed time since report creation")?;
+
+        if elapsed_time < T::MomentsPerDay::get() {
             Ok(())
         } else {
             Err(<Error<T>>::RemoteAttestationTooOld.into())

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -75,7 +75,7 @@ fn list_enclaves() -> Vec<(u64, Enclave<AccountId, Vec<u8>>)> {
 #[test]
 fn add_enclave_works() {
     new_test_ext().execute_with(|| {
-        // set the now in the runtime such that the remote attestation reports are withing accepted range (24h)
+        // set the now in the runtime such that the remote attestation reports are within accepted range (24h)
         Timestamp::set_timestamp(TEST4_TIMESTAMP);
         let signer = get_signer(TEST4_SIGNER_PUB);
         assert_ok!(Registry::register_enclave(
@@ -230,7 +230,7 @@ fn register_enclave_with_to_old_attestation_report_fails() {
 #[test]
 fn update_enclave_url_works() {
     new_test_ext().execute_with(|| {
-        Timestamp::set_timestamp(TEST7_TIMESTAMP);
+        Timestamp::set_timestamp(TEST4_TIMESTAMP);
 
         let signer = get_signer(TEST4_SIGNER_PUB);
         let url2 = "my fancy url".as_bytes();
@@ -262,7 +262,7 @@ fn update_enclave_url_works() {
 #[test]
 fn update_ipfs_hash_works() {
     new_test_ext().execute_with(|| {
-        Timestamp::set_timestamp(TEST7_TIMESTAMP);
+        Timestamp::set_timestamp(TEST4_TIMESTAMP);
 
         let ipfs_hash = "QmYY9U7sQzBYe79tVfiMyJ4prEJoJRWCD8t85j9qjssS9y";
         let shard = H256::default();


### PR DESCRIPTION
* [registry] added ensure_timestamp_within_24_hours
* [ias-verify] change the timestamp type in the report to u64
* [test] update to use timestamp module to set timestamp in unit tests as it is now checked in register enclave
* [mock] extend test runtime to use timestamp module