### PR TITLE
fix timestamp with substratee node

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,6 @@ version = "2.0.0-alpha.7"
 [dev-dependencies]
 hex-literal = "*"
 env_logger = "0.7.1"
-log = "0.4.8"
 
 [dependencies.sp-runtime]
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-substratee-registry"
-version = "0.6.6-sub2.0.0-alpha.7"
+version = "0.6.7-sub2.0.0-alpha.7"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,8 @@ version = "2.0.0-alpha.7"
 
 [dev-dependencies]
 hex-literal = "*"
+env_logger = "0.7.1"
+log = "0.4.8"
 
 [dependencies.sp-runtime]
 default-features = false

--- a/ias-verify/src/lib.rs
+++ b/ias-verify/src/lib.rs
@@ -96,7 +96,7 @@ pub struct SgxReport {
     pub mr_enclave: [u8; 32],
     pub pubkey: [u8; 32],
     pub status: SgxStatus,
-    pub timestamp: u64,
+    pub timestamp: u64, // unix timestamp in milliseconds
 }
 
 type SignatureAlgorithms = &'static [&'static webpki::SignatureAlgorithm];
@@ -306,7 +306,8 @@ fn parse_report(report_raw: &[u8]) -> Result<SgxReport, &'static str> {
         _ => return Err("Failed to fetch timestamp from attestation report"),
     };
 
-    let ra_timestamp: u64 = _ra_timestamp
+    // in milliseconds
+    let ra_timestamp: u64 = (_ra_timestamp * 1000)
         .try_into()
         .map_err(|_| "Error converting report.timestamp to u64")?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ const MAX_URL_LEN: usize = 256;
 pub struct Enclave<PubKey, Url> {
     pub pubkey: PubKey, // FIXME: this is redundant information
     pub mr_enclave: [u8; 32],
-    pub timestamp: u64, // unix epoch
+    pub timestamp: u64, // unix epoch in milliseconds
     pub url: Url,       // utf8 encoded url
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -90,6 +90,7 @@ fn add_enclave_works() {
 #[test]
 fn add_and_remove_enclave_works() {
     new_test_ext().execute_with(|| {
+        let _ = env_logger::init();
         Timestamp::set_timestamp(TEST4_TIMESTAMP);
         let signer = get_signer(TEST4_SIGNER_PUB);
         assert_ok!(Registry::register_enclave(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -53,10 +53,10 @@ const TEST7_MRENCLAVE: [u8; 32] =
     hex!("f4dedfc9e5fcc48443332bc9b23161c34a3c3f5a692eaffdb228db27b704d9d1");
 
 // unix epoch. must be later than this
-const TEST4_TIMESTAMP: u64 = 1587899785;
-const TEST5_TIMESTAMP: u64 = 1587900013;
-const TEST6_TIMESTAMP: u64 = 1587900233;
-const TEST7_TIMESTAMP: u64 = 1587900450;
+const TEST4_TIMESTAMP: u64 = 1587899785000;
+const TEST5_TIMESTAMP: u64 = 1587900013000;
+const TEST6_TIMESTAMP: u64 = 1587900233000;
+const TEST7_TIMESTAMP: u64 = 1587900450000;
 
 const TWENTY_FOUR_HOURS: u64 = 60 * 60 * 24 * 1000;
 
@@ -224,6 +224,19 @@ fn register_enclave_with_to_old_attestation_report_fails() {
                 message: Some(Error::<TestRuntime>::RemoteAttestationTooOld.into())
             })
         );
+    })
+}
+
+#[test]
+fn register_enclave_with_almost_too_old_report_works() {
+    new_test_ext().execute_with(|| {
+        Timestamp::set_timestamp(TEST7_TIMESTAMP + TWENTY_FOUR_HOURS - 1);
+        let signer = get_signer(TEST7_SIGNER_PUB);
+        assert_ok!(Registry::register_enclave(
+            Origin::signed(signer),
+            TEST7_CERT.to_vec(),
+            URL.to_vec()
+        ));
     })
 }
 


### PR DESCRIPTION
There was an inconsistent handling with the timestamps. In the registry timestamps were handled as seconds while the node handles them as milliseconds.

As we set the timestamp in the unittests ourselves, this incoherence was not obvious.