### PR TITLE
mitigate replay attack in unshield

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-substratee-registry"
-version = "0.6.7-sub2.0.0-alpha.7"
+version = "0.6.8-sub2.0.0-alpha.7"
 authors = ["Supercomputing Systems AG <info@scs.ch>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ version = "2.0.0-alpha.7"
 [dev-dependencies]
 hex-literal = "*"
 env_logger = "0.7.1"
+log = "*"
 
 [dependencies.sp-runtime]
 default-features = false
@@ -58,6 +59,9 @@ version = '2.0.0-alpha.7'
 [dev-dependencies.externalities]
 package = "sp-externalities"
 version = "0.8.0-alpha.7"
+
+[dev-dependencies.sp-keyring]
+version = "2.0.0-alpha.7"
 
 [dev-dependencies.balances]
 package = "pallet-balances"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,7 +193,7 @@ decl_module! {
                 T::Currency::transfer(&bonding_account, &public_account, amount, ExistenceRequirement::AllowDeath)?;
                 <ConfirmedCalls>::insert(call_hash, 0);
                 Self::deposit_event(RawEvent::UnshieldedFunds(public_account));
-            } {
+            } else {
                 native::info!("Second confirmation for call: {:?}", call_hash);
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,6 +193,8 @@ decl_module! {
                 T::Currency::transfer(&bonding_account, &public_account, amount, ExistenceRequirement::AllowDeath)?;
                 <ConfirmedCalls>::insert(call_hash, 0);
                 Self::deposit_event(RawEvent::UnshieldedFunds(public_account));
+            } {
+                native::info!("Second confirmation for call: {:?}", call_hash);
             }
 
             <ConfirmedCalls>::mutate(call_hash, |confirmations| {*confirmations += 1 });

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -4,6 +4,7 @@ use crate::{Module, Trait};
 use frame_support::{impl_outer_event, impl_outer_origin, parameter_types, weights::Weight};
 use frame_system as system;
 use sp_core::{sr25519, H256};
+use sp_keyring::AccountKeyring;
 use sp_runtime::{
     testing::Header,
     traits::{BlakeTwo256, IdentityLookup, Verify},
@@ -95,9 +96,11 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
     let mut t = system::GenesisConfig::default()
         .build_storage::<TestRuntime>()
         .unwrap();
-    balances::GenesisConfig::<TestRuntime> { balances: vec![] }
-        .assimilate_storage(&mut t)
-        .unwrap();
+    balances::GenesisConfig::<TestRuntime> {
+        balances: vec![(AccountKeyring::Alice.public(), 1 << 60)],
+    }
+    .assimilate_storage(&mut t)
+    .unwrap();
     let mut ext: sp_io::TestExternalities = t.into();
     ext.execute_with(|| System::set_block_number(1));
     ext


### PR DESCRIPTION
* fn unshield_funds: now has an extra parameter `call_hash` which is stored on chain such that unshield is not executed if multiple workers are sending the unshield

* `call_hash` is now everywhere handled as `H256`